### PR TITLE
Fix for referredUsers method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A referrals system for a laravel projects.",
     "homepage": "http://github.com/pdazcom/laravel-referrals",
     "type": "library",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "require": {
         "php": "^7.0",
         "laravel/framework": "^5.3.0",

--- a/database/migrations/2018_09_25_110004_create_users_table.php
+++ b/database/migrations/2018_09_25_110004_create_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,5 +23,12 @@
     <php>
         <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
         <env name="APP_ENV" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_DEFAULT" value="sqlite"/>
+        <env name="DB_PREFIX" value=""/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_DRIVER" value="sync"/>
     </php>
 </phpunit>

--- a/src/Models/ReferralLink.php
+++ b/src/Models/ReferralLink.php
@@ -60,7 +60,9 @@ class ReferralLink extends Model
     public function referredUsers()
     {
         $usersModel = config('auth.providers.users.model');
-        return $this->hasManyThrough($usersModel, ReferralRelationship::class, 'user_id', 'id', 'id', 'referral_link_id');
+        $list = $this->relationships->map(function($m){
+            return $m->user_id;
+        });
+        return $usersModel::whereIn('id', $list)->get();
     }
-
 }

--- a/tests/Unit/Listeners/ReferUserTest.php
+++ b/tests/Unit/Listeners/ReferUserTest.php
@@ -4,23 +4,23 @@ namespace Pdazcom\Referrals\Tests\Unit;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Orchestra\Testbench\Traits\WithLoadMigrationsFrom;
 use Pdazcom\Referrals\Events\UserReferred;
 use Pdazcom\Referrals\Listeners\ReferUser;
 use Pdazcom\Referrals\Models\ReferralProgram;
 use Pdazcom\Referrals\Tests\TestCase;
 use Mockery as m;
+use Pdazcom\Referrals\Tests\WithLoadMigrations;
 
 class ReferUserTest extends TestCase
 {
-    use WithLoadMigrationsFrom;
     use DatabaseTransactions;
     use DatabaseMigrations;
+    use WithLoadMigrations;
 
     public function setUp()
     {
         parent::setUp();
-        $this->loadMigrationsFrom(__DIR__ . '/../../../database/migrations');
+        $this->loadMigrations();
     }
 
     public function testCreatingRelationship()

--- a/tests/Unit/Listeners/RewardUserTest.php
+++ b/tests/Unit/Listeners/RewardUserTest.php
@@ -4,26 +4,24 @@ namespace Pdazcom\Referrals\Tests\Unit;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Orchestra\Testbench\Traits\WithLoadMigrationsFrom;
 use Pdazcom\Referrals\Events\ReferralCase;
-use Pdazcom\Referrals\Events\UserReferred;
-use Pdazcom\Referrals\Listeners\ReferUser;
 use Pdazcom\Referrals\Listeners\RewardUser;
 use Pdazcom\Referrals\Models\ReferralProgram;
 use Pdazcom\Referrals\Programs\ExampleProgram;
+use Pdazcom\Referrals\Tests\WithLoadMigrations;
 use Pdazcom\Referrals\Tests\TestCase;
 use Mockery as m;
 
 class RewardUserTest extends TestCase
 {
-    use WithLoadMigrationsFrom;
     use DatabaseTransactions;
     use DatabaseMigrations;
+    use WithLoadMigrations;
 
     public function setUp()
     {
         parent::setUp();
-        $this->loadMigrationsFrom(__DIR__ . '/../../../database/migrations');
+        $this->loadMigrations();
     }
 
     public function testRewardUser()

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -5,22 +5,22 @@ namespace Pdazcom\Referrals\Tests\Unit;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\Request;
-use Orchestra\Testbench\Traits\WithLoadMigrationsFrom;
 use Pdazcom\Referrals\Http\Middleware\StoreReferralCode;
 use Pdazcom\Referrals\Models\ReferralProgram;
 use Pdazcom\Referrals\Tests\TestCase;
 use Mockery as m;
+use Pdazcom\Referrals\Tests\WithLoadMigrations;
 
 class MiddlewareTest extends TestCase
 {
-    use WithLoadMigrationsFrom;
     use DatabaseTransactions;
     use DatabaseMigrations;
+    use WithLoadMigrations;
 
     public function setUp()
     {
         parent::setUp();
-        $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        $this->loadMigrations();
     }
 
     public function testSetCookie()

--- a/tests/Unit/Models/ReferralLinkTest.php
+++ b/tests/Unit/Models/ReferralLinkTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace Pdazcom\Referrals\Tests\Unit\Models;
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Pdazcom\Referrals\Models\ReferralProgram;
+use Pdazcom\Referrals\Tests\TestCase;
+use Pdazcom\Referrals\Tests\WithLoadMigrations;
+
+class ReferralLinkTest extends TestCase
+{
+    use DatabaseTransactions;
+    use DatabaseMigrations;
+    use WithLoadMigrations;
+
+    public function setUp()
+    {
+        parent::setup();
+        $this->loadMigrations();
+        $this->app['config']->set('auth.providers.users.model', User::class);
+    }
+
+    public function testReferredUsers()
+    {
+        $referralUser = User::create();
+
+        $recruitUser1 = User::create();
+
+        User::create();
+
+        $recruitUser2 = User::create();
+
+
+        $program = ReferralProgram::create([
+            'name' => 'example',
+            'title' => 'Test',
+            'description' => 'Test description',
+            'uri' => 'test',
+        ]);
+
+        /** @var \Pdazcom\Referrals\Models\ReferralLink $refLink */
+        $refLink = $program->links()->create([
+            'user_id' => $referralUser->id,
+        ]);
+
+        $refLink->relationships()->create([
+            'user_id' => $recruitUser1->id,
+        ]);
+
+        $refLink->relationships()->create([
+            'user_id' => $recruitUser2->id,
+        ]);
+
+        $this->assertCount(2, $refLink->referredUsers());
+        $user_ids = $refLink->referredUsers()->map(function($user) {
+            return $user->id;
+        });
+        $this->assertEquals(2, $user_ids[0]);
+        $this->assertEquals(4, $user_ids[1]);
+    }
+}

--- a/tests/WithLoadMigrations.php
+++ b/tests/WithLoadMigrations.php
@@ -1,0 +1,14 @@
+<?php
+namespace Pdazcom\Referrals\Tests;
+
+use Orchestra\Testbench\Traits\WithLoadMigrationsFrom;
+
+trait WithLoadMigrations
+{
+    use WithLoadMigrationsFrom;
+
+    protected function loadMigrations()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+    }
+}


### PR DESCRIPTION
Fixed `referredUsers()` method to return the correct entries.

Additionally, I've added "unit" tests for ReferralLink class. While they interact with an in-memory database they do not do the traditional testing of going through Controllers and such like normal in `Feature` testing for Laravel projects. Happy to move these into `Feature` folder but they seem isolated to an appropriate degree and really fast