### PR TITLE
Fix typo dafault->default in published migration for referral_program_id

### DIFF
--- a/database/migrations/2017_09_23_110003_add_allowed_ref_program_to_users.php
+++ b/database/migrations/2017_09_23_110003_add_allowed_ref_program_to_users.php
@@ -18,7 +18,7 @@ class AddAllowedRefProgramToUsers extends Migration
         }
 
         Schema::table($this->getUsersTable(), function (Blueprint $table) {
-            $table->integer('referral_program_id')->unsigned()->nullable()->dafault(null);
+            $table->integer('referral_program_id')->unsigned()->nullable()->default(null);
 
             $table->foreign('referral_program_id')
                 ->references('id')


### PR DESCRIPTION
## Summary

- Fixes a one-character typo `dafault` → `default` in `database/migrations/2017_09_23_110003_add_allowed_ref_program_to_users.php`
- Without this fix the published migration throws a fatal error when run (`Call to undefined method ... dafault()`)

Closes #16

## Test plan
- [ ] Run `php artisan migrate` after publishing the migration and confirm it completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)